### PR TITLE
ページ枠作り（各ルート作り）

### DIFF
--- a/application/app/consts/pages.ts
+++ b/application/app/consts/pages.ts
@@ -10,8 +10,14 @@ export const Pages: Record<
   login: { name: "ログイン", path: "/login" },
   examStart: { name: "試験開始", path: "/exam/start" },
   examQuestion: { name: "問題", path: "/exam/question" },
+  examCompletion: { name: "試験終了", path: "/exam/completion" },
 
   // 企業用画面
   corpLogin: { name: "企業ログイン", path: "/corp/login" },
-  // ぜんぜん作ってない
+  corpHome: { name: "ホーム", path: "/corp/home" },
+  corpExaminees: { name: "受験者管理", path: "/corp/examinees" },
+  corpQuestions: { name: "問題管理", path: "/corp/questions" },
+  corpExams: { name: "試験管理", path: "/corp/exams" },
+  corpScores: { name: "成績集計", path: "/corp/scores" },
+  corpSettings: { name: "設定", path: "/corp/settings" },
 };

--- a/application/app/routes/_private.exam.completion/index.tsx
+++ b/application/app/routes/_private.exam.completion/index.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>試験終了画面</Title>
+    </>
+  );
+}

--- a/application/app/routes/corp._private.examinees/index.tsx
+++ b/application/app/routes/corp._private.examinees/index.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>企業／受験者管理画面</Title>
+    </>
+  );
+}

--- a/application/app/routes/corp._private.exams/index.tsx
+++ b/application/app/routes/corp._private.exams/index.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>企業／試験管理画面</Title>
+    </>
+  );
+}

--- a/application/app/routes/corp._private.home/index.tsx
+++ b/application/app/routes/corp._private.home/index.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>企業／ホーム画面（通知画面）</Title>
+    </>
+  );
+}

--- a/application/app/routes/corp._private.questions/index.tsx
+++ b/application/app/routes/corp._private.questions/index.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>企業／問題管理画面</Title>
+    </>
+  );
+}

--- a/application/app/routes/corp._private.scores/index.tsx
+++ b/application/app/routes/corp._private.scores/index.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>企業／成績集計画面</Title>
+    </>
+  );
+}

--- a/application/app/routes/corp._private.settings/index.tsx
+++ b/application/app/routes/corp._private.settings/index.tsx
@@ -1,0 +1,7 @@
+export default function index() {
+  return (
+    <div>
+      <h1>企業／設定画面</h1>
+    </div>
+  );
+}

--- a/application/app/routes/corp._private.settings/index.tsx
+++ b/application/app/routes/corp._private.settings/index.tsx
@@ -1,7 +1,9 @@
+import { Title } from "@mantine/core";
+
 export default function index() {
   return (
-    <div>
-      <h1>企業／設定画面</h1>
-    </div>
+    <>
+      <Title order={1}>企業／設定画面</Title>
+    </>
   );
 }

--- a/application/app/routes/corp._public.login.tsx
+++ b/application/app/routes/corp._public.login.tsx
@@ -1,0 +1,9 @@
+import { Title } from "@mantine/core";
+
+export default function index() {
+  return (
+    <>
+      <Title order={1}>企業／ログイン画面</Title>
+    </>
+  );
+}


### PR DESCRIPTION
<!-- 
- [ ] TODO:以下の設定をしてください
  - Reviewers
    - Webルーレットで決まったレビュワーを設定する
    - https://jp.piliapp.com/random/wheel/
      - 項目:
安部友弘(T0m0hir0ABE)
蓮沼淳史(hedgehog248)
幡江美遥(hataemiharu)
稲村純(j-inamura)
石川渚(Nagisa-Ishikawa)
長元幸輝(nagamoto03)
毛利togo(もうりとうご)
  - Assignees
    - 自分を設定する
  - Labels, Projects, Milestone
    - 設定不要
  - Development
    - issueを指定する
-->

# 実装概要
- デザインに合わせてroutesに階層をつくり、それぞれにindex.tsxを作成。
- 企業ページは全て`corp/`以下に配置。
- ログインページのみ未ログインでアクセスできるよう`_public`以下に配置。

# レビュー観点
- ページ名が最適かどうか
- 階層構造が適しているかどうか

# Notionのissueリンク
https://www.notion.so/divx/110807e48ca381d4bd0bde64965d6e5e
